### PR TITLE
Multicore support for BP AXI top

### DIFF
--- a/axi/v/bp_axi_top.sv
+++ b/axi/v/bp_axi_top.sv
@@ -130,12 +130,12 @@ module bp_axi_top
 
   // DMA interface from BP to cache2axi
   `declare_bsg_cache_dma_pkt_s(daddr_width_p);
-  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_pkt_lo;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_pkt_v_lo, axi_dma_pkt_ready_and_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] axi_dma_data_lo;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_data_v_lo, axi_dma_data_ready_and_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] axi_dma_data_li;
-  logic [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_data_v_li, axi_dma_data_ready_and_lo;
+  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] c2a_dma_pkt_lo;
+  logic [num_cce_p-1:0][l2_banks_p-1:0] c2a_dma_pkt_v_lo, c2a_dma_pkt_ready_and_li;
+  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] c2a_dma_data_lo;
+  logic [num_cce_p-1:0][l2_banks_p-1:0] c2a_dma_data_v_lo, c2a_dma_data_ready_and_li;
+  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] c2a_dma_data_li;
+  logic [num_cce_p-1:0][l2_banks_p-1:0] c2a_dma_data_v_li, c2a_dma_data_ready_and_lo;
 
   if (cce_type_p == e_cce_uce)
     begin : u
@@ -189,17 +189,17 @@ module bp_axi_top
         ,.io_resp_last_o(io_resp_last_lo)
 
         // DMA (memory) to cache2axi
-        ,.dma_pkt_o(axi_dma_pkt_lo)
-        ,.dma_pkt_v_o(axi_dma_pkt_v_lo)
-        ,.dma_pkt_ready_and_i(axi_dma_pkt_ready_and_li)
+        ,.dma_pkt_o(c2a_dma_pkt_lo)
+        ,.dma_pkt_v_o(c2a_dma_pkt_v_lo)
+        ,.dma_pkt_ready_and_i(c2a_dma_pkt_ready_and_li)
 
-        ,.dma_data_i(axi_dma_data_li)
-        ,.dma_data_v_i(axi_dma_data_v_li)
-        ,.dma_data_ready_and_o(axi_dma_data_ready_and_lo)
+        ,.dma_data_i(c2a_dma_data_li)
+        ,.dma_data_v_i(c2a_dma_data_v_li)
+        ,.dma_data_ready_and_o(c2a_dma_data_ready_and_lo)
 
-        ,.dma_data_o(axi_dma_data_lo)
-        ,.dma_data_v_o(axi_dma_data_v_lo)
-        ,.dma_data_ready_and_i(axi_dma_data_ready_and_li)
+        ,.dma_data_o(c2a_dma_data_lo)
+        ,.dma_data_v_o(c2a_dma_data_v_lo)
+        ,.dma_data_ready_and_i(c2a_dma_data_ready_and_li)
         );
 
       bp_me_axil_client
@@ -532,23 +532,23 @@ module bp_axi_top
               localparam col_lp     = i%mc_x_dim_p;
               localparam col_pos_lp = (i/mc_x_dim_p)*l2_banks_p+j;
 
-              assign axi_dma_pkt_lo[i][j] = dma_pkt_lo[col_lp][col_pos_lp];
-              assign axi_dma_pkt_v_lo[i][j] = dma_pkt_v_lo[col_lp][col_pos_lp];
-              assign dma_pkt_yumi_li[col_lp][col_pos_lp] = axi_dma_pkt_ready_and_li[i][j] & axi_dma_pkt_v_lo[i][j];
+              assign c2a_dma_pkt_lo[i][j] = dma_pkt_lo[col_lp][col_pos_lp];
+              assign c2a_dma_pkt_v_lo[i][j] = dma_pkt_v_lo[col_lp][col_pos_lp];
+              assign dma_pkt_yumi_li[col_lp][col_pos_lp] = c2a_dma_pkt_ready_and_li[i][j] & c2a_dma_pkt_v_lo[i][j];
 
-              assign axi_dma_data_lo[i][j] = dma_data_lo[col_lp][col_pos_lp];
-              assign axi_dma_data_v_lo[i][j] = dma_data_v_lo[col_lp][col_pos_lp];
-              assign dma_data_yumi_li[col_lp][col_pos_lp] = axi_dma_data_ready_and_li[i][j] & axi_dma_data_v_lo[i][j];
+              assign c2a_dma_data_lo[i][j] = dma_data_lo[col_lp][col_pos_lp];
+              assign c2a_dma_data_v_lo[i][j] = dma_data_v_lo[col_lp][col_pos_lp];
+              assign dma_data_yumi_li[col_lp][col_pos_lp] = c2a_dma_data_ready_and_li[i][j] & c2a_dma_data_v_lo[i][j];
 
-              assign dma_data_li[col_lp][col_pos_lp] = axi_dma_data_li[i][j];
-              assign dma_data_v_li[col_lp][col_pos_lp] = axi_dma_data_v_li[i][j];
-              assign axi_dma_data_ready_and_lo[i][j] = dma_data_ready_and_lo[col_lp][col_pos_lp];
+              assign dma_data_li[col_lp][col_pos_lp] = c2a_dma_data_li[i][j];
+              assign dma_data_v_li[col_lp][col_pos_lp] = c2a_dma_data_v_li[i][j];
+              assign c2a_dma_data_ready_and_lo[i][j] = dma_data_ready_and_lo[col_lp][col_pos_lp];
             end
         end
     end // multicore
 
   // Unswizzle the dram
-  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_pkt;
+  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] c2a_dma_pkt;
   for (genvar i = 0; i < num_cce_p; i++)
     begin : rof3
       for (genvar j = 0; j < l2_banks_p; j++)
@@ -557,10 +557,10 @@ module bp_axi_top
           bp_me_dram_hash_decode
            #(.bp_params_p(bp_params_p))
             dma_addr_hash
-            (.daddr_i(axi_dma_pkt_lo[i][j].addr)
-             ,.daddr_o(axi_dma_pkt[i][j].addr)
+            (.daddr_i(c2a_dma_pkt_lo[i][j].addr)
+             ,.daddr_o(c2a_dma_pkt[i][j].addr)
              );
-          assign axi_dma_pkt[i][j].write_not_read = axi_dma_pkt_lo[i][j].write_not_read;
+          assign c2a_dma_pkt[i][j].write_not_read = c2a_dma_pkt_lo[i][j].write_not_read;
         end
     end
 
@@ -577,17 +577,17 @@ module bp_axi_top
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
 
-      ,.dma_pkt_i(axi_dma_pkt)
-      ,.dma_pkt_v_i(axi_dma_pkt_v_lo)
-      ,.dma_pkt_yumi_o(axi_dma_pkt_ready_and_li)
+      ,.dma_pkt_i(c2a_dma_pkt)
+      ,.dma_pkt_v_i(c2a_dma_pkt_v_lo)
+      ,.dma_pkt_yumi_o(c2a_dma_pkt_ready_and_li)
 
-      ,.dma_data_o(axi_dma_data_li)
-      ,.dma_data_v_o(axi_dma_data_v_li)
-      ,.dma_data_ready_i(axi_dma_data_ready_and_lo)
+      ,.dma_data_o(c2a_dma_data_li)
+      ,.dma_data_v_o(c2a_dma_data_v_li)
+      ,.dma_data_ready_i(c2a_dma_data_ready_and_lo)
 
-      ,.dma_data_i(axi_dma_data_lo)
-      ,.dma_data_v_i(axi_dma_data_v_lo)
-      ,.dma_data_yumi_o(axi_dma_data_ready_and_li)
+      ,.dma_data_i(c2a_dma_data_lo)
+      ,.dma_data_v_i(c2a_dma_data_v_lo)
+      ,.dma_data_yumi_o(c2a_dma_data_ready_and_li)
 
       ,.axi_awid_o(m_axi_awid_o)
       ,.axi_awaddr_addr_o(m_axi_awaddr_o)

--- a/axi/v/bp_axi_top.sv
+++ b/axi/v/bp_axi_top.sv
@@ -124,26 +124,30 @@ module bp_axi_top
    , input [1:0]                               m_axi_rresp_i
    );
 
-  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
-  bp_bedrock_mem_header_s io_cmd_header_li, io_resp_header_lo;
-  logic [uce_fill_width_p-1:0] io_cmd_data_li, io_resp_data_lo;
-  logic io_cmd_v_li, io_cmd_ready_and_lo, io_cmd_last_li;
-  logic io_resp_v_lo, io_resp_ready_and_li, io_resp_last_lo;
-  bp_bedrock_mem_header_s io_cmd_header_lo, io_resp_header_li;
-  logic [uce_fill_width_p-1:0] io_cmd_data_lo, io_resp_data_li;
-  logic io_cmd_v_lo, io_cmd_ready_and_li, io_cmd_last_lo;
-  logic io_resp_v_li, io_resp_ready_and_lo, io_resp_last_li;
+  localparam io_data_width_p = (cce_type_p == e_cce_uce) ? uce_fill_width_p : bedrock_data_width_p;
 
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+
+  // DMA interface from BP to cache2axi
   `declare_bsg_cache_dma_pkt_s(daddr_width_p);
-  bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt_lo;
-  logic [l2_banks_p-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_lo;
-  logic [l2_banks_p-1:0] dma_data_v_lo, dma_data_yumi_li;
-  logic [l2_banks_p-1:0][l2_fill_width_p-1:0] dma_data_li;
-  logic [l2_banks_p-1:0] dma_data_v_li, dma_data_ready_and_lo;
+  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_pkt_lo;
+  logic [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_pkt_v_lo, axi_dma_pkt_ready_and_li;
+  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] axi_dma_data_lo;
+  logic [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_data_v_lo, axi_dma_data_ready_and_li;
+  logic [num_cce_p-1:0][l2_banks_p-1:0][l2_fill_width_p-1:0] axi_dma_data_li;
+  logic [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_data_v_li, axi_dma_data_ready_and_lo;
 
   if (cce_type_p == e_cce_uce)
     begin : u
+      bp_bedrock_mem_header_s io_cmd_header_li, io_resp_header_lo;
+      logic [io_data_width_p-1:0] io_cmd_data_li, io_resp_data_lo;
+      logic io_cmd_v_li, io_cmd_ready_and_lo, io_resp_v_lo, io_resp_ready_and_li;
+      logic io_cmd_last_li, io_resp_last_lo;
+      bp_bedrock_mem_header_s io_cmd_header_lo, io_resp_header_li;
+      logic [io_data_width_p-1:0] io_cmd_data_lo, io_resp_data_li;
+      logic io_cmd_v_lo, io_cmd_ready_and_li, io_resp_v_li, io_resp_ready_and_lo;
+      logic io_cmd_last_lo, io_resp_last_li;
+
       // note: bp_unicore has L2 cache; (bp_unicore_lite does not, but does not have dma_* interface
       // and would need mem_cmd/mem_resp-to-axi converter to be written.)
       bp_unicore
@@ -184,19 +188,70 @@ module bp_axi_top
         ,.io_resp_ready_and_i(io_resp_ready_and_li)
         ,.io_resp_last_o(io_resp_last_lo)
 
-        ,.dma_pkt_o(dma_pkt_lo)
-        ,.dma_pkt_v_o(dma_pkt_v_lo)
-        ,.dma_pkt_ready_and_i(dma_pkt_yumi_li)
+        // DMA (memory) to cache2axi
+        ,.dma_pkt_o(axi_dma_pkt_lo)
+        ,.dma_pkt_v_o(axi_dma_pkt_v_lo)
+        ,.dma_pkt_ready_and_i(axi_dma_pkt_ready_and_li)
 
-        ,.dma_data_i(dma_data_li)
-        ,.dma_data_v_i(dma_data_v_li)
-        ,.dma_data_ready_and_o(dma_data_ready_and_lo)
+        ,.dma_data_i(axi_dma_data_li)
+        ,.dma_data_v_i(axi_dma_data_v_li)
+        ,.dma_data_ready_and_o(axi_dma_data_ready_and_lo)
 
-        ,.dma_data_o(dma_data_lo)
-        ,.dma_data_v_o(dma_data_v_lo)
-        ,.dma_data_ready_and_i(dma_data_yumi_li)
+        ,.dma_data_o(axi_dma_data_lo)
+        ,.dma_data_v_o(axi_dma_data_v_lo)
+        ,.dma_data_ready_and_i(axi_dma_data_ready_and_li)
         );
-    end
+
+      bp_me_axil_client
+       #(.bp_params_p(bp_params_p)
+         ,.axil_data_width_p(axil_data_width_p)
+         ,.axil_addr_width_p(axil_addr_width_p)
+         )
+       axil2io
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.io_cmd_header_o(io_cmd_header_li)
+         ,.io_cmd_data_o(io_cmd_data_li)
+         ,.io_cmd_v_o(io_cmd_v_li)
+         ,.io_cmd_last_o(io_cmd_last_li)
+         ,.io_cmd_ready_and_i(io_cmd_ready_and_lo)
+
+         ,.io_resp_header_i(io_resp_header_lo)
+         ,.io_resp_data_i(io_resp_data_lo)
+         ,.io_resp_v_i(io_resp_v_lo)
+         ,.io_resp_last_i(io_resp_last_lo)
+         ,.io_resp_ready_and_o(io_resp_ready_and_li)
+
+         ,.lce_id_i(lce_id_width_p'('b10))
+         ,.did_i(did_width_p'('1))
+         ,.*
+         );
+
+      bp_me_axil_master
+       #(.bp_params_p(bp_params_p)
+         ,.axil_data_width_p(axil_data_width_p)
+         ,.axil_addr_width_p(axil_addr_width_p)
+         )
+       io2axil
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
+
+         ,.io_cmd_header_i(io_cmd_header_lo)
+         ,.io_cmd_data_i(io_cmd_data_lo)
+         ,.io_cmd_v_i(io_cmd_v_lo)
+         ,.io_cmd_last_i(io_cmd_last_lo)
+         ,.io_cmd_ready_and_o(io_cmd_ready_and_li)
+
+         ,.io_resp_header_o(io_resp_header_li)
+         ,.io_resp_data_o(io_resp_data_li)
+         ,.io_resp_v_o(io_resp_v_li)
+         ,.io_resp_last_o(io_resp_last_li)
+         ,.io_resp_ready_and_i(io_resp_ready_and_lo)
+
+         ,.*
+         );
+    end // unicore
   else
     begin : m
       `declare_bsg_ready_and_link_sif_s(io_noc_flit_width_p, bp_io_noc_ral_link_s);
@@ -205,7 +260,7 @@ module bp_axi_top
       bp_io_noc_ral_link_s proc_resp_link_li, proc_resp_link_lo;
       bp_io_noc_ral_link_s stub_cmd_link_li, stub_resp_link_li;
       bp_io_noc_ral_link_s stub_cmd_link_lo, stub_resp_link_lo;
-      bp_mem_noc_ral_link_s dram_cmd_link_lo, dram_resp_link_li;
+      bp_mem_noc_ral_link_s [mc_x_dim_p-1:0] dram_cmd_link_lo, dram_resp_link_li;
 
       assign stub_cmd_link_li  = '0;
       assign stub_resp_link_li = '0;
@@ -264,12 +319,37 @@ module bp_axi_top
                                     ,ready_and_rev: send_cmd_link_lo.ready_and_rev
                                     };
 
-      bp_me_cce_to_mem_link_send
+      bp_bedrock_mem_header_s io_cmd_header_li;
+      logic [io_data_width_p-1:0] io_cmd_data_li;
+      logic io_cmd_header_v_li, io_cmd_header_ready_and_lo;
+      logic io_cmd_data_v_li, io_cmd_data_ready_and_lo;
+      logic io_cmd_last_li, io_cmd_has_data_li;
+
+      bp_bedrock_mem_header_s io_resp_header_lo;
+      logic [io_data_width_p-1:0] io_resp_data_lo;
+      logic io_resp_header_v_lo, io_resp_header_ready_and_li;
+      logic io_resp_data_v_lo, io_resp_data_ready_and_li;
+      logic io_resp_last_lo, io_resp_has_data_lo;
+
+      bp_bedrock_mem_header_s io_cmd_header_lo;
+      logic [io_data_width_p-1:0] io_cmd_data_lo;
+      logic io_cmd_header_v_lo, io_cmd_header_ready_and_li;
+      logic io_cmd_data_v_lo, io_cmd_data_ready_and_li;
+      logic io_cmd_last_lo, io_cmd_has_data_lo;
+
+      bp_bedrock_mem_header_s io_resp_header_li;
+      logic [io_data_width_p-1:0] io_resp_data_li;
+      logic io_resp_header_v_li, io_resp_header_ready_and_lo;
+      logic io_resp_data_v_li, io_resp_data_ready_and_lo;
+      logic io_resp_last_li, io_resp_has_data_li;
+
+      bp_me_bedrock_mem_to_link
        #(.bp_params_p(bp_params_p)
          ,.flit_width_p(io_noc_flit_width_p)
          ,.cord_width_p(io_noc_cord_width_p)
          ,.cid_width_p(io_noc_cid_width_p)
          ,.len_width_p(io_noc_len_width_p)
+         ,.payload_mask_p(mem_cmd_payload_mask_gp)
          )
        send_link
         (.clk_i(clk_i)
@@ -278,29 +358,35 @@ module bp_axi_top
          ,.dst_cord_i(dst_cord_lo)
          ,.dst_cid_i('0)
 
-         ,.mem_cmd_header_i(io_cmd_header_li)
-         ,.mem_cmd_data_i(io_cmd_data_li)
-         ,.mem_cmd_v_i(io_cmd_v_li)
-         ,.mem_cmd_ready_and_o(io_cmd_ready_and_lo)
-         ,.mem_cmd_last_i(io_cmd_last_li)
+         ,.mem_header_i(io_cmd_header_li)
+         ,.mem_header_v_i(io_cmd_header_v_li)
+         ,.mem_header_ready_and_o(io_cmd_header_ready_and_lo)
+         ,.mem_has_data_i(io_cmd_has_data_li)
+         ,.mem_data_i(io_cmd_data_li)
+         ,.mem_data_v_i(io_cmd_data_v_li)
+         ,.mem_data_ready_and_o(io_cmd_data_ready_and_lo)
+         ,.mem_last_i(io_cmd_last_li)
 
-         ,.mem_resp_header_o(io_resp_header_lo)
-         ,.mem_resp_data_o(io_resp_data_lo)
-         ,.mem_resp_v_o(io_resp_v_lo)
-         ,.mem_resp_yumi_i(io_resp_ready_and_li & io_resp_v_lo)
-         ,.mem_resp_last_o(io_resp_last_lo)
+         ,.mem_header_o(io_resp_header_lo)
+         ,.mem_header_v_o(io_resp_header_v_lo)
+         ,.mem_header_ready_and_i(io_resp_header_ready_and_li)
+         ,.mem_has_data_o(io_resp_has_data_lo)
+         ,.mem_data_o(io_resp_data_lo)
+         ,.mem_data_v_o(io_resp_data_v_lo)
+         ,.mem_data_ready_and_i(io_resp_data_ready_and_li)
+         ,.mem_last_o(io_resp_last_lo)
 
-
-         ,.cmd_link_o(send_cmd_link_lo)
-         ,.resp_link_i(send_resp_link_li)
+         ,.link_o(send_cmd_link_lo)
+         ,.link_i(send_resp_link_li)
          );
 
-      bp_me_cce_to_mem_link_recv
+      bp_me_bedrock_mem_to_link
        #(.bp_params_p(bp_params_p)
          ,.flit_width_p(io_noc_flit_width_p)
          ,.cord_width_p(io_noc_cord_width_p)
          ,.cid_width_p(io_noc_cid_width_p)
          ,.len_width_p(io_noc_len_width_p)
+         ,.payload_mask_p(mem_resp_payload_mask_gp)
          )
        recv_link
         (.clk_i(clk_i)
@@ -309,127 +395,180 @@ module bp_axi_top
          ,.dst_cord_i(io_resp_header_li.payload.did)
          ,.dst_cid_i('0)
 
-         ,.mem_cmd_header_o(io_cmd_header_lo)
-         ,.mem_cmd_data_o(io_cmd_data_lo)
-         ,.mem_cmd_v_o(io_cmd_v_lo)
-         ,.mem_cmd_yumi_i(io_cmd_ready_and_li & io_cmd_v_lo)
-         ,.mem_cmd_last_o(io_cmd_last_lo)
+         ,.mem_header_o(io_cmd_header_lo)
+         ,.mem_header_v_o(io_cmd_header_v_lo)
+         ,.mem_header_ready_and_i(io_cmd_header_ready_and_li)
+         ,.mem_has_data_o(io_cmd_has_data_lo)
+         ,.mem_data_o(io_cmd_data_lo)
+         ,.mem_data_v_o(io_cmd_data_v_lo)
+         ,.mem_data_ready_and_i(io_cmd_data_ready_and_li)
+         ,.mem_last_o(io_cmd_last_lo)
 
-         ,.mem_resp_header_i(io_resp_header_li)
-         ,.mem_resp_data_i(io_resp_data_li)
-         ,.mem_resp_v_i(io_resp_v_li)
-         ,.mem_resp_ready_and_o(io_resp_ready_and_lo)
-         ,.mem_resp_last_i(io_resp_last_li)
+         ,.mem_header_i(io_resp_header_li)
+         ,.mem_header_v_i(io_resp_header_v_li)
+         ,.mem_header_ready_and_o(io_resp_header_ready_and_lo)
+         ,.mem_has_data_i(io_resp_has_data_li)
+         ,.mem_data_i(io_resp_data_li)
+         ,.mem_data_v_i(io_resp_data_v_li)
+         ,.mem_data_ready_and_o(io_resp_data_ready_and_lo)
+         ,.mem_last_i(io_resp_last_li)
 
-         ,.cmd_link_i(recv_cmd_link_li)
-         ,.resp_link_o(recv_resp_link_lo)
+         ,.link_i(recv_cmd_link_li)
+         ,.link_o(recv_resp_link_lo)
          );
 
-      `declare_bsg_cache_wh_header_flit_s(mem_noc_flit_width_p, mem_noc_cord_width_p, mem_noc_len_width_p, mem_noc_cid_width_p);
-      bsg_cache_wh_header_flit_s header_flit;
-      assign header_flit = dram_cmd_link_lo.data;
-      wire [`BSG_SAFE_CLOG2(l2_banks_p)-1:0] dma_id_li = header_flit.src_cid;
-      bsg_wormhole_to_cache_dma_fanout
-       #(.wh_flit_width_p(mem_noc_flit_width_p)
-         ,.wh_cid_width_p(mem_noc_cid_width_p)
-         ,.wh_len_width_p(mem_noc_len_width_p)
-         ,.wh_cord_width_p(mem_noc_cord_width_p)
-
-         ,.num_dma_p(l2_banks_p)
-         ,.dma_addr_width_p(daddr_width_p)
-         ,.dma_burst_len_p(l2_block_size_in_fill_p)
+      bp_me_axil_to_burst
+       #(.bp_params_p(bp_params_p)
+         ,.axil_data_width_p(axil_data_width_p)
+         ,.axil_addr_width_p(axil_addr_width_p)
          )
-       wh_to_cache_dma
+       axil2io
         (.clk_i(clk_i)
          ,.reset_i(reset_i)
 
-         ,.wh_link_sif_i(dram_cmd_link_lo)
-         ,.wh_dma_id_i(dma_id_li)
-         ,.wh_link_sif_o(dram_resp_link_li)
+         ,.io_cmd_header_o(io_cmd_header_li)
+         ,.io_cmd_header_v_o(io_cmd_header_v_li)
+         ,.io_cmd_has_data_o(io_cmd_has_data_li)
+         ,.io_cmd_header_ready_and_i(io_cmd_header_ready_and_lo)
+         ,.io_cmd_data_o(io_cmd_data_li)
+         ,.io_cmd_data_v_o(io_cmd_data_v_li)
+         ,.io_cmd_last_o(io_cmd_last_li)
+         ,.io_cmd_data_ready_and_i(io_cmd_data_ready_and_lo)
 
-         ,.dma_pkt_o(dma_pkt_lo)
-         ,.dma_pkt_v_o(dma_pkt_v_lo)
-         ,.dma_pkt_yumi_i(dma_pkt_yumi_li)
+         ,.io_resp_header_i(io_resp_header_lo)
+         ,.io_resp_header_v_i(io_resp_header_v_lo)
+         ,.io_resp_has_data_i(io_resp_has_data_lo)
+         ,.io_resp_header_ready_and_o(io_resp_header_ready_and_li)
+         ,.io_resp_data_i(io_resp_data_lo)
+         ,.io_resp_data_v_i(io_resp_data_v_lo)
+         ,.io_resp_last_i(io_resp_last_lo)
+         ,.io_resp_data_ready_and_o(io_resp_data_ready_and_li)
 
-         ,.dma_data_o(dma_data_lo)
-         ,.dma_data_v_o(dma_data_v_lo)
-         ,.dma_data_yumi_i(dma_data_yumi_li)
-
-         ,.dma_data_i(dma_data_li)
-         ,.dma_data_v_i(dma_data_v_li)
-         ,.dma_data_ready_and_o(dma_data_ready_and_lo)
+         ,.lce_id_i(lce_id_width_p'('b10))
+         ,.did_i(did_width_p'('1))
+         ,.*
          );
-    end
 
-  bp_me_axil_client
-   #(.bp_params_p(bp_params_p)
-     ,.axil_data_width_p(axil_data_width_p)
-     ,.axil_addr_width_p(axil_addr_width_p)
-     )
-   axil2io
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+      bp_me_burst_to_axil
+       #(.bp_params_p(bp_params_p)
+         ,.axil_data_width_p(axil_data_width_p)
+         ,.axil_addr_width_p(axil_addr_width_p)
+         )
+       io2axil
+        (.clk_i(clk_i)
+         ,.reset_i(reset_i)
 
-     ,.io_cmd_header_o(io_cmd_header_li)
-     ,.io_cmd_data_o(io_cmd_data_li)
-     ,.io_cmd_v_o(io_cmd_v_li)
-     ,.io_cmd_ready_and_i(io_cmd_ready_and_lo)
-     ,.io_cmd_last_o(io_cmd_last_li)
+         ,.io_cmd_header_i(io_cmd_header_lo)
+         ,.io_cmd_header_v_i(io_cmd_header_v_lo)
+         ,.io_cmd_has_data_i(io_cmd_has_data_lo)
+         ,.io_cmd_header_ready_and_o(io_cmd_header_ready_and_li)
+         ,.io_cmd_data_i(io_cmd_data_lo)
+         ,.io_cmd_data_v_i(io_cmd_data_v_lo)
+         ,.io_cmd_last_i(io_cmd_last_lo)
+         ,.io_cmd_data_ready_and_o(io_cmd_data_ready_and_li)
 
-     ,.io_resp_header_i(io_resp_header_lo)
-     ,.io_resp_data_i(io_resp_data_lo)
-     ,.io_resp_v_i(io_resp_v_lo)
-     ,.io_resp_ready_and_o(io_resp_ready_and_li)
-     ,.io_resp_last_i(io_resp_last_lo)
+         ,.io_resp_header_o(io_resp_header_li)
+         ,.io_resp_header_v_o(io_resp_header_v_li)
+         ,.io_resp_has_data_o(io_resp_has_data_li)
+         ,.io_resp_header_ready_and_i(io_resp_header_ready_and_lo)
+         ,.io_resp_data_o(io_resp_data_li)
+         ,.io_resp_data_v_o(io_resp_data_v_li)
+         ,.io_resp_last_o(io_resp_last_li)
+         ,.io_resp_data_ready_and_i(io_resp_data_ready_and_lo)
 
-     ,.lce_id_i(lce_id_width_p'('b10))
-     ,.did_i(did_width_p'('1))
-     ,.*
-     );
+         ,.*
+         );
 
-  bp_me_axil_master
-   #(.bp_params_p(bp_params_p)
-     ,.axil_data_width_p(axil_data_width_p)
-     ,.axil_addr_width_p(axil_addr_width_p)
-     )
-   io2axil
-    (.clk_i(clk_i)
-     ,.reset_i(reset_i)
+      `declare_bsg_cache_wh_header_flit_s(mem_noc_flit_width_p, mem_noc_cord_width_p, mem_noc_len_width_p, mem_noc_cid_width_p);
+      localparam dma_per_col_lp = num_cce_p/mc_x_dim_p*l2_banks_p;
+      bsg_cache_dma_pkt_s [mc_x_dim_p-1:0][dma_per_col_lp-1:0] dma_pkt_lo;
+      logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0] dma_pkt_v_lo, dma_pkt_yumi_li;
+      logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0][l2_fill_width_p-1:0] dma_data_lo;
+      logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0] dma_data_v_lo, dma_data_yumi_li;
+      logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0][l2_fill_width_p-1:0] dma_data_li;
+      logic [mc_x_dim_p-1:0][dma_per_col_lp-1:0] dma_data_v_li, dma_data_ready_and_lo;
+      for (genvar i = 0; i < mc_x_dim_p; i++)
+        begin : column
+          bsg_cache_wh_header_flit_s header_flit;
+          assign header_flit = dram_cmd_link_lo[i].data;
+          wire [`BSG_SAFE_CLOG2(dma_per_col_lp)-1:0] dma_id_li =
+            l2_banks_p*(header_flit.src_cord-1)+header_flit.src_cid;
+          bsg_wormhole_to_cache_dma_fanout
+           #(.wh_flit_width_p(mem_noc_flit_width_p)
+             ,.wh_cid_width_p(mem_noc_cid_width_p)
+             ,.wh_len_width_p(mem_noc_len_width_p)
+             ,.wh_cord_width_p(mem_noc_cord_width_p)
 
-     ,.io_cmd_header_i(io_cmd_header_lo)
-     ,.io_cmd_data_i(io_cmd_data_lo)
-     ,.io_cmd_v_i(io_cmd_v_lo)
-     ,.io_cmd_ready_and_o(io_cmd_ready_and_li)
-     ,.io_cmd_last_i(io_cmd_last_lo)
+             ,.num_dma_p(dma_per_col_lp)
+             ,.dma_addr_width_p(daddr_width_p)
+             ,.dma_burst_len_p(l2_block_size_in_fill_p)
+             )
+           wh_to_cache_dma
+            (.clk_i(clk_i)
+             ,.reset_i(reset_i)
 
-     ,.io_resp_header_o(io_resp_header_li)
-     ,.io_resp_data_o(io_resp_data_li)
-     ,.io_resp_v_o(io_resp_v_li)
-     ,.io_resp_ready_and_i(io_resp_ready_and_lo)
-     ,.io_resp_last_o(io_resp_last_li)
+             ,.wh_link_sif_i(dram_cmd_link_lo[i])
+             ,.wh_dma_id_i(dma_id_li)
+             ,.wh_link_sif_o(dram_resp_link_li[i])
 
-     ,.*
-     );
+             ,.dma_pkt_o(dma_pkt_lo[i])
+             ,.dma_pkt_v_o(dma_pkt_v_lo[i])
+             ,.dma_pkt_yumi_i(dma_pkt_yumi_li[i])
+
+             ,.dma_data_i(dma_data_li[i])
+             ,.dma_data_v_i(dma_data_v_li[i])
+             ,.dma_data_ready_and_o(dma_data_ready_and_lo[i])
+
+             ,.dma_data_o(dma_data_lo[i])
+             ,.dma_data_v_o(dma_data_v_lo[i])
+             ,.dma_data_yumi_i(dma_data_yumi_li[i])
+             );
+        end
+      // Transpose the DMA IDs
+      for (genvar i = 0; i < num_cce_p; i++)
+        begin : rof1
+          for (genvar j = 0; j < l2_banks_p; j++)
+            begin : rof2
+              localparam col_lp     = i%mc_x_dim_p;
+              localparam col_pos_lp = (i/mc_x_dim_p)*l2_banks_p+j;
+
+              assign axi_dma_pkt_lo[i][j] = dma_pkt_lo[col_lp][col_pos_lp];
+              assign axi_dma_pkt_v_lo[i][j] = dma_pkt_v_lo[col_lp][col_pos_lp];
+              assign dma_pkt_yumi_li[col_lp][col_pos_lp] = axi_dma_pkt_ready_and_li[i][j] & axi_dma_pkt_v_lo[i][j];
+
+              assign axi_dma_data_lo[i][j] = dma_data_lo[col_lp][col_pos_lp];
+              assign axi_dma_data_v_lo[i][j] = dma_data_v_lo[col_lp][col_pos_lp];
+              assign dma_data_yumi_li[col_lp][col_pos_lp] = axi_dma_data_ready_and_li[i][j] & axi_dma_data_v_lo[i][j];
+
+              assign dma_data_li[col_lp][col_pos_lp] = axi_dma_data_li[i][j];
+              assign dma_data_v_li[col_lp][col_pos_lp] = axi_dma_data_v_li[i][j];
+              assign axi_dma_data_ready_and_lo[i][j] = dma_data_ready_and_lo[col_lp][col_pos_lp];
+            end
+        end
+    end // multicore
 
   // Unswizzle the dram
-  bsg_cache_dma_pkt_s [l2_banks_p-1:0] dma_pkt;
-  for (genvar i = 0; i < l2_banks_p; i++)
-    begin : address_hash
-      logic [daddr_width_p-1:0] daddr_lo;
-      bp_me_dram_hash_decode
-       #(.bp_params_p(bp_params_p))
-        dma_addr_hash
-        (.daddr_i(dma_pkt_lo[i].addr)
-         ,.daddr_o(dma_pkt[i].addr)
-         );
-      assign dma_pkt[i].write_not_read = dma_pkt_lo[i].write_not_read;
+  bsg_cache_dma_pkt_s [num_cce_p-1:0][l2_banks_p-1:0] axi_dma_pkt;
+  for (genvar i = 0; i < num_cce_p; i++)
+    begin : rof3
+      for (genvar j = 0; j < l2_banks_p; j++)
+        begin : address_hash
+          logic [daddr_width_p-1:0] daddr_lo;
+          bp_me_dram_hash_decode
+           #(.bp_params_p(bp_params_p))
+            dma_addr_hash
+            (.daddr_i(axi_dma_pkt_lo[i][j].addr)
+             ,.daddr_o(axi_dma_pkt[i][j].addr)
+             );
+          assign axi_dma_pkt[i][j].write_not_read = axi_dma_pkt_lo[i][j].write_not_read;
+        end
     end
 
    bsg_cache_to_axi
     #(.addr_width_p(daddr_width_p)
       ,.data_width_p(l2_fill_width_p)
       ,.block_size_in_words_p(l2_block_size_in_fill_p)
-      ,.num_cache_p(l2_banks_p)
+      ,.num_cache_p(num_cce_p*l2_banks_p)
       ,.axi_data_width_p(axi_data_width_p)
       ,.axi_id_width_p(axi_id_width_p)
       ,.axi_burst_len_p(l2_block_width_p/axi_data_width_p)
@@ -438,17 +577,17 @@ module bp_axi_top
      (.clk_i(clk_i)
       ,.reset_i(reset_i)
 
-      ,.dma_pkt_i(dma_pkt)
-      ,.dma_pkt_v_i(dma_pkt_v_lo)
-      ,.dma_pkt_yumi_o(dma_pkt_yumi_li)
+      ,.dma_pkt_i(axi_dma_pkt)
+      ,.dma_pkt_v_i(axi_dma_pkt_v_lo)
+      ,.dma_pkt_yumi_o(axi_dma_pkt_ready_and_li)
 
-      ,.dma_data_o(dma_data_li)
-      ,.dma_data_v_o(dma_data_v_li)
-      ,.dma_data_ready_i(dma_data_ready_and_lo)
+      ,.dma_data_o(axi_dma_data_li)
+      ,.dma_data_v_o(axi_dma_data_v_li)
+      ,.dma_data_ready_i(axi_dma_data_ready_and_lo)
 
-      ,.dma_data_i(dma_data_lo)
-      ,.dma_data_v_i(dma_data_v_lo)
-      ,.dma_data_yumi_o(dma_data_yumi_li)
+      ,.dma_data_i(axi_dma_data_lo)
+      ,.dma_data_v_i(axi_dma_data_v_lo)
+      ,.dma_data_yumi_o(axi_dma_data_ready_and_li)
 
       ,.axi_awid_o(m_axi_awid_o)
       ,.axi_awaddr_addr_o(m_axi_awaddr_o)
@@ -494,9 +633,6 @@ module bp_axi_top
       ,.axi_awaddr_cache_id_o()
       ,.axi_araddr_cache_id_o()
       );
-
-  if (num_core_p > 1)
-    $error("Multiple cores are not currently supported in zynqparrot");
 
 endmodule
 

--- a/axi/v/bp_me_axil_to_burst.sv
+++ b/axi/v/bp_me_axil_to_burst.sv
@@ -1,0 +1,258 @@
+/*
+ * Name:
+ *  bp_me_axil_to_burst.sv
+ *
+ * Description:
+ *  This module converts an AXI4-Lite Subordinate interface to
+ *  BP BedRock Burst Command Out / Response In. This module is a
+ *  minimal AXI4-Lite Subordinate, and assumes IO responses are
+ *  returned in order with respect to IO commands issued.
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_axil_to_burst
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+  `declare_bp_proc_params(bp_params_p)
+  `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+  , parameter io_data_width_p = (cce_type_p == e_cce_uce) ? uce_fill_width_p : bedrock_data_width_p
+
+  , parameter axil_data_width_p = 32
+  , parameter axil_addr_width_p = 32
+  )
+
+  (//==================== GLOBAL SIGNALS =======================
+   input                                        clk_i
+   , input                                      reset_i
+
+   //==================== BP-BURST SIGNALS =====================
+   , input [lce_id_width_p-1:0]                 lce_id_i
+   , input [did_width_p-1:0]                    did_i
+
+   , output logic [mem_header_width_lp-1:0]     io_cmd_header_o
+   , output logic                               io_cmd_header_v_o
+   , output logic                               io_cmd_has_data_o
+   , input                                      io_cmd_header_ready_and_i
+   , output logic [io_data_width_p-1:0]         io_cmd_data_o
+   , output logic                               io_cmd_data_v_o
+   , output logic                               io_cmd_last_o
+   , input                                      io_cmd_data_ready_and_i
+
+   , input [mem_header_width_lp-1:0]            io_resp_header_i
+   , input                                      io_resp_header_v_i
+   , input                                      io_resp_has_data_i
+   , output logic                               io_resp_header_ready_and_o
+   , input [io_data_width_p-1:0]                io_resp_data_i
+   , input                                      io_resp_data_v_i
+   , input                                      io_resp_last_i
+   , output logic                               io_resp_data_ready_and_o
+
+   //====================== AXI4-LITE ==========================
+   // WRITE ADDRESS CHANNEL SIGNALS
+   , input [axil_addr_width_p-1:0]              s_axil_awaddr_i
+   , input axi_prot_type_e                      s_axil_awprot_i
+   , input                                      s_axil_awvalid_i
+   , output logic                               s_axil_awready_o
+
+   // WRITE DATA CHANNEL SIGNALS
+   , input [axil_data_width_p-1:0]              s_axil_wdata_i
+   , input [(axil_data_width_p>>3)-1:0]         s_axil_wstrb_i
+   , input                                      s_axil_wvalid_i
+   , output logic                               s_axil_wready_o
+
+   // WRITE RESPONSE CHANNEL SIGNALS
+   , output axi_resp_type_e                     s_axil_bresp_o
+   , output logic                               s_axil_bvalid_o
+   , input                                      s_axil_bready_i
+
+   // READ ADDRESS CHANNEL SIGNALS
+   , input [axil_addr_width_p-1:0]              s_axil_araddr_i
+   , input axi_prot_type_e                      s_axil_arprot_i
+   , input                                      s_axil_arvalid_i
+   , output logic                               s_axil_arready_o
+
+   // READ DATA CHANNEL SIGNALS
+   , output logic [axil_data_width_p-1:0]       s_axil_rdata_o
+   , output axi_resp_type_e                     s_axil_rresp_o
+   , output logic                               s_axil_rvalid_o
+   , input                                      s_axil_rready_i
+  );
+
+  wire unused = &{s_axil_awprot_i, s_axil_arprot_i, io_resp_has_data_i, io_resp_last_i};
+
+  // declaring i/o command and response struct type and size
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_resp_header);
+
+  // buffer response headers for s_axil_rresp_o and saxil_bresp_o arbitration
+  bp_bedrock_mem_header_s io_resp_header_li;
+  logic io_resp_header_v_li, io_resp_header_yumi_lo;
+  bsg_two_fifo
+   #(.width_p($bits(bp_bedrock_mem_header_s)))
+   resp_header_fifo
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.v_i(io_resp_header_v_i)
+     ,.data_i(io_resp_header_cast_i)
+     ,.ready_o(io_resp_header_ready_and_o)
+     ,.v_o(io_resp_header_v_li)
+     ,.data_o(io_resp_header_li)
+     ,.yumi_i(io_resp_header_yumi_lo)
+     );
+
+  // Declaring all possible states
+  typedef enum logic [1:0]
+  {
+    e_ready
+    , e_write_addr_rx
+    , e_write_data_rx
+    , e_read_addr_rx
+  } state_e;
+  state_e state_n, state_r;
+
+  bp_bedrock_msg_size_e wsize, rsize;
+  always_comb
+    case (s_axil_wstrb_i)
+      (axil_data_width_p>>3)'('h1): wsize = e_bedrock_msg_size_1;
+      (axil_data_width_p>>3)'('h3): wsize = e_bedrock_msg_size_2;
+      (axil_data_width_p>>3)'('hF): wsize = e_bedrock_msg_size_4;
+      // (axil_data_width_p>>3)'('hFF):
+      default: wsize = e_bedrock_msg_size_8;
+    endcase
+
+  // read accesses are sized by AXI4-Lite data bus size
+  assign rsize = (axil_data_width_p == 64) ? e_bedrock_msg_size_8 : e_bedrock_msg_size_4;
+
+  // AXIL read/write to IO command out
+  always_comb begin
+    state_n = state_r;
+
+    // BP side
+    io_cmd_header_v_o                   = 1'b0;
+    io_cmd_has_data_o                   = 1'b0;
+    io_cmd_header_cast_o                = '0;
+    io_cmd_header_cast_o.payload.lce_id = lce_id_i;
+    io_cmd_header_cast_o.payload.did    = did_i;
+    io_cmd_data_v_o                     = 1'b0;
+    io_cmd_last_o                       = 1'b1;
+    io_cmd_data_o                       = s_axil_wdata_i;
+
+    // WRITE ADDRESS CHANNEL SIGNALS
+    s_axil_awready_o = '0;
+
+    // WRITE DATA CHANNEL SIGNALS
+    s_axil_wready_o  = '0;
+
+    // READ ADDRESS CHANNEL SIGNALS
+    s_axil_arready_o = '0;
+
+    unique case (state_r)
+      // check for incoming write or read, prioritize write
+      e_ready: begin
+        state_n = s_axil_awvalid_i
+                  ? e_write_addr_rx
+                  : s_axil_arvalid_i
+                    ? e_read_addr_rx
+                    : state_r;
+      end
+
+      // send IO write command
+      e_write_addr_rx: begin
+        io_cmd_header_cast_o.addr     = s_axil_awaddr_i;
+        io_cmd_header_cast_o.msg_type = e_bedrock_mem_uc_wr;
+        io_cmd_header_cast_o.size     = wsize;
+        io_cmd_header_v_o             = s_axil_awvalid_i;
+        io_cmd_has_data_o             = 1'b1;
+        s_axil_awready_o              = io_cmd_header_ready_and_i;
+        state_n = (io_cmd_header_v_o & io_cmd_header_ready_and_i)
+                  ? e_write_data_rx
+                  : state_r;
+      end
+
+      // send IO write data
+      e_write_data_rx: begin
+        io_cmd_data_v_o = s_axil_wvalid_i;
+        s_axil_wready_o = io_cmd_data_ready_and_i;
+        state_n = (io_cmd_data_v_o & io_cmd_data_ready_and_i)
+                  ? e_ready
+                  : state_r;
+      end
+
+      // send IO read command
+      e_read_addr_rx: begin
+        io_cmd_header_cast_o.addr     = s_axil_araddr_i;
+        io_cmd_header_cast_o.msg_type = e_bedrock_mem_uc_rd;
+        io_cmd_header_cast_o.size     = rsize;
+        io_cmd_header_v_o             = s_axil_arvalid_i;
+        s_axil_arready_o              = io_cmd_header_ready_and_i;
+        state_n = (io_cmd_header_v_o & io_cmd_header_ready_and_i)
+                  ? e_ready
+                  : state_r;
+      end
+
+      default: begin end
+    endcase
+  end
+
+  // IO response in to AXIL rd/wr response
+  always_comb begin
+
+    // read responses have data, send if header and data ready
+    // consume response data only if header also valid in buffer
+    s_axil_rresp_o  = e_axi_resp_okay;
+    s_axil_rdata_o  = io_resp_data_i;
+    s_axil_rvalid_o = io_resp_header_v_li & io_resp_data_v_i
+                      & io_resp_header_li.msg_type inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd};
+    io_resp_data_ready_and_o = io_resp_header_v_li & s_axil_rready_i;
+
+    // write responses have no data, send if header is write response
+    s_axil_bresp_o  = e_axi_resp_okay;
+    s_axil_bvalid_o = io_resp_header_v_li
+                      & io_resp_header_li.msg_type inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr};
+
+    io_resp_header_yumi_lo = (s_axil_rvalid_o & s_axil_rready_i) | (s_axil_bvalid_o & s_axil_bready_i);
+  end
+
+  // synopsys sync_set_reset "reset_i"
+  always_ff @(posedge clk_i)
+    if (reset_i)
+      state_r <= e_ready;
+    else
+      state_r <= state_n;
+
+  if (axil_data_width_p != 64 && axil_data_width_p != 32)
+    $error("AXI4-LITE only supports a data width of 32 or 64 bits.");
+
+  if (io_data_width_p < axil_data_width_p)
+    $error("I/O data width must be at least AXI4-LITE data width");
+
+  //synopsys translate_off
+  initial begin
+    $display("## bp_me_axil_to_burst: instantiating with axil_data_width_p=%d, axil_addr_width_p=%d (%m)\n",axil_data_width_p,axil_addr_width_p);
+  end
+
+  always_ff @(negedge clk_i) begin
+    assert (reset_i !== '0 || s_axil_awprot_i == 3'b000)
+      else $error("AXI4-LITE access permission mode is not supported.");
+    assert (reset_i !== '0 || ~s_axil_wvalid_i || (s_axil_wstrb_i inside {'h1, 'h3, 'hf, 'hff}))
+      else $error("Invalid write strobe encountered");
+    assert (reset_i !== '0 || ~io_resp_header_v_i
+            || io_resp_header_cast_i.size <= e_bedrock_msg_size_8
+            || axil_data_width_p == 64)
+      else $error("64-bit BedRock response not supported with 32-bit AXIL data width");
+    assert (reset_i !== '0 || ~io_resp_header_v_i
+            || (io_resp_header_cast_i.msg_type inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd} && io_resp_has_data_i)
+            || (io_resp_header_cast_i.msg_type inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr} && ~io_resp_has_data_i)
+           )
+      else $error("BedRock response type and has data signal inconsistent");
+    assert (reset_i !== '0 || ~io_resp_data_v_i || io_resp_last_i)
+      else $error("BedRock response data must be single beat");
+  end
+  // synopsys translate_on
+
+endmodule
+

--- a/axi/v/bp_me_axil_to_burst.sv
+++ b/axi/v/bp_me_axil_to_burst.sv
@@ -15,6 +15,7 @@
 module bp_me_axil_to_burst
  import bp_common_pkg::*;
  import bp_me_pkg::*;
+ import bsg_axi_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
   `declare_bp_proc_params(bp_params_p)
   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)

--- a/axi/v/bp_me_burst_to_axil.sv
+++ b/axi/v/bp_me_burst_to_axil.sv
@@ -1,0 +1,286 @@
+/*
+ * Name:
+ *  bp_me_burst_to_axil.sv
+ *
+ * Description:
+ *  This module converts an BP Bedrock Burst Command In / Response Out
+ *  to an AXI4-Lite Manager interface. This module is a minimal AXI4-Lite
+ *  Manager, supporting one request at a time. IO write commands are
+ *  restricted to single data beat writes.
+ *
+ */
+
+`include "bp_common_defines.svh"
+`include "bp_me_defines.svh"
+
+module bp_me_burst_to_axil
+ import bp_common_pkg::*;
+ import bp_me_pkg::*;
+ #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+  `declare_bp_proc_params(bp_params_p)
+  `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)
+  , parameter io_data_width_p = (cce_type_p == e_cce_uce) ? uce_fill_width_p : bedrock_data_width_p
+
+  , parameter axil_data_width_p = 32
+  , parameter axil_addr_width_p  = 32
+  )
+ (//==================== GLOBAL SIGNALS =======================
+  input                                        clk_i
+  , input                                      reset_i
+
+  //==================== BP-BURST SIGNALS =====================
+  , input [mem_header_width_lp-1:0]            io_cmd_header_i
+  , input                                      io_cmd_header_v_i
+  , input                                      io_cmd_has_data_i
+  , output logic                               io_cmd_header_ready_and_o
+  , input [io_data_width_p-1:0]                io_cmd_data_i
+  , input                                      io_cmd_data_v_i
+  , input                                      io_cmd_last_i
+  , output logic                               io_cmd_data_ready_and_o
+
+  , output logic [mem_header_width_lp-1:0]     io_resp_header_o
+  , output logic                               io_resp_header_v_o
+  , output logic                               io_resp_has_data_o
+  , input                                      io_resp_header_ready_and_i
+  , output logic [io_data_width_p-1:0]         io_resp_data_o
+  , output logic                               io_resp_data_v_o
+  , output logic                               io_resp_last_o
+  , input                                      io_resp_data_ready_and_i
+
+  //====================== AXI4-LITE ==========================
+  // WRITE ADDRESS CHANNEL SIGNALS
+  , output logic [axil_addr_width_p-1:0]       m_axil_awaddr_o
+  , output axi_prot_type_e                     m_axil_awprot_o
+  , output logic                               m_axil_awvalid_o
+  , input                                      m_axil_awready_i
+
+  // WRITE DATA CHANNEL SIGNALS
+  , output logic [axil_data_width_p-1:0]       m_axil_wdata_o
+  , output logic [(axil_data_width_p>>3)-1:0]  m_axil_wstrb_o
+  , output logic                               m_axil_wvalid_o
+  , input                                      m_axil_wready_i
+
+  // WRITE RESPONSE CHANNEL SIGNALS
+  , input axi_resp_type_e                      m_axil_bresp_i
+  , input                                      m_axil_bvalid_i
+  , output logic                               m_axil_bready_o
+
+  // READ ADDRESS CHANNEL SIGNALS
+  , output logic [axil_addr_width_p-1:0]       m_axil_araddr_o
+  , output axi_prot_type_e                     m_axil_arprot_o
+  , output logic                               m_axil_arvalid_o
+  , input                                      m_axil_arready_i
+
+  // READ DATA CHANNEL SIGNALS
+  , input [axil_data_width_p-1:0]              m_axil_rdata_i
+  , input axi_resp_type_e                      m_axil_rresp_i
+  , input                                      m_axil_rvalid_i
+  , output logic                               m_axil_rready_o
+  );
+
+  // declaring i/o command and response struct type and size
+  `declare_bp_bedrock_mem_if(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p);
+  `bp_cast_i(bp_bedrock_mem_header_s, io_cmd_header);
+  `bp_cast_o(bp_bedrock_mem_header_s, io_resp_header);
+
+  // command header buffer
+  bp_bedrock_mem_header_s io_cmd_header_li;
+  logic io_cmd_has_data_li;
+  bsg_dff_reset_en
+   #(.width_p($bits(bp_bedrock_mem_header_s)+1))
+   cmd_header_reg
+    (.clk_i(clk_i)
+     ,.reset_i(reset_i)
+     ,.data_i({io_cmd_has_data_i, io_cmd_header_cast_i})
+     ,.en_i(io_cmd_header_v_i & io_cmd_header_ready_and_o)
+     ,.data_o({io_cmd_has_data_li, io_cmd_header_li})
+     );
+
+  // read data out select
+  localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(axil_data_width_p>>3);
+  localparam size_width_lp = `BSG_WIDTH(byte_offset_width_lp);
+  wire [byte_offset_width_lp-1:0] resp_sel_li = io_cmd_header_li.addr[0+:byte_offset_width_lp];
+  wire [size_width_lp-1:0] resp_size_li = io_cmd_header_li.size;
+  bsg_bus_pack
+   #(.in_width_p(axil_data_width_p), .out_width_p(io_data_width_p))
+   resp_data_bus_pack
+    (.data_i(m_axil_rdata_i)
+     ,.sel_i(resp_sel_li)
+     ,.size_i(resp_size_li)
+     ,.data_o(io_resp_data_o)
+     );
+
+  // declaring all possible states
+  typedef enum logic [2:0]
+  {
+    e_ready
+    , e_read_addr
+    , e_read_header
+    , e_read_data
+    , e_write_addr_and_data
+    , e_write_addr
+    , e_write_data
+    , e_write_resp
+  } state_e;
+  state_e state_n, state_r;
+
+  // combinational Logic
+  always_comb
+    begin
+      state_n = state_r;
+
+      io_cmd_header_ready_and_o = 1'b0;
+      io_cmd_data_ready_and_o = 1'b0;
+
+      io_resp_header_v_o = 1'b0;
+      io_resp_header_cast_o = io_cmd_header_li;
+      // response has data is opposite of command has data
+      io_resp_has_data_o = ~io_cmd_has_data_li;
+      io_resp_data_v_o = 1'b0;
+      io_resp_last_o = 1'b1;
+
+      // WRITE ADDRESS CHANNEL SIGNALS
+      m_axil_awaddr_o  = io_cmd_header_li.addr[0+:axil_addr_width_p];
+      m_axil_awprot_o  = e_axi_prot_dsn;
+      m_axil_awvalid_o = 1'b0;
+
+      // WRITE DATA CHANNEL SIGNALS
+      m_axil_wdata_o   = io_cmd_data_i;
+      m_axil_wvalid_o  = 1'b0;
+
+      // READ ADDRESS CHANNEL SIGNALS
+      m_axil_araddr_o  = io_cmd_header_li.addr[0+:axil_addr_width_p];
+      m_axil_arprot_o  = e_axi_prot_dsn;
+      m_axil_arvalid_o = 1'b0;
+
+      // READ DATA CHANNEL SIGNALS
+      m_axil_rready_o  = 1'b0;
+
+      // WRITE RESPONSE CHANNEL SIGNALS
+      m_axil_bready_o  = 1'b0;
+
+      case (io_cmd_header_li.size)
+        e_bedrock_msg_size_1 : m_axil_wstrb_o = (axil_data_width_p>>3)'('h1);
+        e_bedrock_msg_size_2 : m_axil_wstrb_o = (axil_data_width_p>>3)'('h3);
+        e_bedrock_msg_size_4 : m_axil_wstrb_o = (axil_data_width_p>>3)'('hF);
+        // e_bedrock_msg_size_8 :
+        default : m_axil_wstrb_o = (axil_data_width_p>>3)'('hFF);
+      endcase
+
+      case (state_r)
+        // consume io cmd
+        e_ready: begin
+          io_cmd_header_ready_and_o = 1'b1;
+          state_n = (io_cmd_header_v_i & io_cmd_header_ready_and_o)
+                    ? io_cmd_has_data_i
+                      ? e_write_addr_and_data
+                      : e_read_addr
+                    : state_r;
+        end
+
+        // send write address and data
+        // subordinate is allowed to wait for both to be valid
+        e_write_addr_and_data: begin
+          m_axil_awvalid_o = 1'b1;
+          m_axil_wvalid_o = io_cmd_data_v_i;
+          io_cmd_data_ready_and_o = m_axil_wready_i;
+          state_n = (m_axil_awvalid_o & m_axil_awready_i) & (m_axil_wvalid_o & m_axil_wready_i)
+                    ? e_write_resp
+                    : (m_axil_awvalid_o & m_axil_awready_i)
+                      ? e_write_data
+                      : (m_axil_wvalid_o & m_axil_wready_i)
+                        ? e_write_addr
+                        : state_r;
+        end
+
+        // send write address, data already sent
+        e_write_addr: begin
+          m_axil_awvalid_o = 1'b1;
+          state_n = m_axil_awready_i ? e_write_resp : state_r;
+        end
+
+        // send write data, address already sent
+        e_write_data: begin
+          m_axil_wvalid_o = 1'b1;
+          io_cmd_data_ready_and_o = m_axil_wready_i;
+          state_n = m_axil_wready_i ? e_write_resp : state_r;
+        end
+
+        // consume write response, issue response header
+        e_write_resp: begin
+          m_axil_bready_o = io_resp_header_ready_and_i;
+          io_resp_header_v_o = m_axil_bvalid_i;
+          state_n = (io_resp_header_v_o & io_resp_header_ready_and_i)
+                    ? e_ready
+                    : state_r;
+        end
+
+        // send read address
+        e_read_addr: begin
+          m_axil_arvalid_o = 1'b1;
+          state_n = m_axil_arready_i ? e_read_header : state_r;
+        end
+
+        // send read response header
+        e_read_header: begin
+          io_resp_header_v_o = 1'b1;
+          state_n = (io_resp_header_v_o & io_resp_header_ready_and_i)
+                    ? e_read_data
+                    : state_r;
+        end
+
+        // consume read data, issue response data
+        e_read_data: begin
+          m_axil_rready_o = io_resp_data_ready_and_i;
+          io_resp_data_v_o = m_axil_rvalid_i;
+          state_n = (io_resp_data_v_o & io_resp_data_ready_and_i)
+                    ? e_ready
+                    : state_r;
+        end
+
+        default : begin end
+      endcase
+    end
+
+  // synopsys sync_set_reset "reset_i"
+  always_ff @(posedge clk_i) begin
+    if (reset_i) begin
+      state_r <= e_ready;
+    end
+    else begin
+      state_r <= state_n;
+    end
+  end
+
+  if (axil_data_width_p != 32 && axil_data_width_p != 64)
+    $error("AXI4-LITE only supports a data width of 32 or 64 bits");
+
+  if (io_data_width_p < axil_data_width_p)
+    $error("I/O data width must be at least AXI4-LITE data width");
+
+  //synopsys translate_off
+  initial begin
+    $display("## bp_me_burst_to_axil: instantiating with axil_data_width_p=%d, axil_addr_width_p=%d (%m)\n",axil_data_width_p,axil_addr_width_p);
+  end
+
+  always_ff @(negedge clk_i) begin
+    // give a warning if the client device has an error response
+    assert (reset_i !== '0 || ~m_axil_rvalid_i || m_axil_rresp_i == '0)
+      else $error("Client device has an error response to reads");
+    assert (reset_i !== '0 || ~m_axil_bvalid_i || m_axil_bresp_i == '0)
+      else $error("Client device has an error response to writes");
+    assert (reset_i !== '0 || ~io_cmd_header_v_i
+            || io_cmd_header_cast_i.size <= e_bedrock_msg_size_8
+            || axil_data_width_p == 64)
+      else $error("64-bit BedRock command not supported with 32-bit AXIL data width");
+    assert (reset_i !== '0 || ~io_cmd_header_v_i
+            || (io_cmd_header_cast_i.msg_type inside {e_bedrock_mem_uc_rd, e_bedrock_mem_rd} && ~io_cmd_has_data_i)
+            || (io_cmd_header_cast_i.msg_type inside {e_bedrock_mem_uc_wr, e_bedrock_mem_wr} && io_cmd_has_data_i)
+           )
+      else $error("BedRock command type and has data signal inconsistent");
+    assert (reset_i !== '0 || ~io_cmd_data_v_i || io_cmd_last_i)
+      else $error("BedRock command data must be single beat");
+  end
+  //synopsys translate_on
+
+endmodule

--- a/axi/v/bp_me_burst_to_axil.sv
+++ b/axi/v/bp_me_burst_to_axil.sv
@@ -16,6 +16,7 @@
 module bp_me_burst_to_axil
  import bp_common_pkg::*;
  import bp_me_pkg::*;
+ import bsg_axi_pkg::*;
  #(parameter bp_params_e bp_params_p = e_bp_default_cfg
   `declare_bp_proc_params(bp_params_p)
   `declare_bp_bedrock_mem_if_widths(paddr_width_p, did_width_p, lce_id_width_p, lce_assoc_p)


### PR DESCRIPTION
This PR adds support for multicore BP configs in the top-level BP axi module.

Two changes are made:
1. addition of BedRock Burst - AXIL converters
2. refactor of bp_axi_top for multicore configs