### PR TITLE
Remove enum type from ports

### DIFF
--- a/axi/v/bp_me_axil_to_burst.sv
+++ b/axi/v/bp_me_axil_to_burst.sv
@@ -54,7 +54,7 @@ module bp_me_axil_to_burst
    //====================== AXI4-LITE ==========================
    // WRITE ADDRESS CHANNEL SIGNALS
    , input [axil_addr_width_p-1:0]              s_axil_awaddr_i
-   , input axi_prot_type_e                      s_axil_awprot_i
+   , input [2:0]                                s_axil_awprot_i
    , input                                      s_axil_awvalid_i
    , output logic                               s_axil_awready_o
 
@@ -65,19 +65,19 @@ module bp_me_axil_to_burst
    , output logic                               s_axil_wready_o
 
    // WRITE RESPONSE CHANNEL SIGNALS
-   , output axi_resp_type_e                     s_axil_bresp_o
+   , output logic [1:0]                         s_axil_bresp_o
    , output logic                               s_axil_bvalid_o
    , input                                      s_axil_bready_i
 
    // READ ADDRESS CHANNEL SIGNALS
    , input [axil_addr_width_p-1:0]              s_axil_araddr_i
-   , input axi_prot_type_e                      s_axil_arprot_i
+   , input [2:0]                                s_axil_arprot_i
    , input                                      s_axil_arvalid_i
    , output logic                               s_axil_arready_o
 
    // READ DATA CHANNEL SIGNALS
    , output logic [axil_data_width_p-1:0]       s_axil_rdata_o
-   , output axi_resp_type_e                     s_axil_rresp_o
+   , output logic [1:0]                         s_axil_rresp_o
    , output logic                               s_axil_rvalid_o
    , input                                      s_axil_rready_i
   );

--- a/axi/v/bp_me_burst_to_axil.sv
+++ b/axi/v/bp_me_burst_to_axil.sv
@@ -51,7 +51,7 @@ module bp_me_burst_to_axil
   //====================== AXI4-LITE ==========================
   // WRITE ADDRESS CHANNEL SIGNALS
   , output logic [axil_addr_width_p-1:0]       m_axil_awaddr_o
-  , output axi_prot_type_e                     m_axil_awprot_o
+  , output logic [2:0]                         m_axil_awprot_o
   , output logic                               m_axil_awvalid_o
   , input                                      m_axil_awready_i
 
@@ -62,19 +62,19 @@ module bp_me_burst_to_axil
   , input                                      m_axil_wready_i
 
   // WRITE RESPONSE CHANNEL SIGNALS
-  , input axi_resp_type_e                      m_axil_bresp_i
+  , input [1:0]                                m_axil_bresp_i
   , input                                      m_axil_bvalid_i
   , output logic                               m_axil_bready_o
 
   // READ ADDRESS CHANNEL SIGNALS
   , output logic [axil_addr_width_p-1:0]       m_axil_araddr_o
-  , output axi_prot_type_e                     m_axil_arprot_o
+  , output logic [2:0]                         m_axil_arprot_o
   , output logic                               m_axil_arvalid_o
   , input                                      m_axil_arready_i
 
   // READ DATA CHANNEL SIGNALS
   , input [axil_data_width_p-1:0]              m_axil_rdata_i
-  , input axi_resp_type_e                      m_axil_rresp_i
+  , input [1:0]                                m_axil_rresp_i
   , input                                      m_axil_rvalid_i
   , output logic                               m_axil_rready_o
   );


### PR DESCRIPTION
Having the enum type in the ports is inconvenient from an integration POV, as some tools will not allow you to assign to/from logic, and our enums are not typical of the outside world