### PR TITLE
Nerf outstanding transactions to 1

### DIFF
--- a/axi/v/bp_me_axil_client.sv
+++ b/axi/v/bp_me_axil_client.sv
@@ -13,7 +13,6 @@ module bp_me_axil_client
   , parameter axil_data_width_p = 32
   , parameter axil_addr_width_p = 32
   , localparam axil_mask_width_lp = axil_data_width_p>>3
-  , parameter num_outstanding_p = 8
   )
 
   (//==================== GLOBAL SIGNALS =======================
@@ -85,7 +84,6 @@ module bp_me_axil_client
   bsg_axil_fifo_client
    #(.axil_data_width_p(axil_data_width_p)
      ,.axil_addr_width_p(axil_addr_width_p)
-     ,.fifo_els_p(num_outstanding_p)
      )
    fifo_client
     (.clk_i(clk_i)

--- a/axi/v/bsg_axil_fifo_client.sv
+++ b/axi/v/bsg_axil_fifo_client.sv
@@ -5,7 +5,6 @@ module bsg_axil_fifo_client
  import bsg_axi_pkg::*;
  #(parameter `BSG_INV_PARAM(axil_data_width_p)
    , parameter `BSG_INV_PARAM(axil_addr_width_p)
-   , parameter `BSG_INV_PARAM(fifo_els_p)
 
    , localparam axil_mask_width_lp = axil_data_width_p >> 3
    )
@@ -61,8 +60,8 @@ module bsg_axil_fifo_client
 
   logic [axil_addr_width_p-1:0] araddr_li;
   logic araddr_v_li, araddr_yumi_lo;
-  bsg_fifo_1r1w_small
-   #(.width_p(axil_addr_width_p), .els_p(fifo_els_p))
+  bsg_one_fifo
+   #(.width_p(axil_addr_width_p))
    araddr_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -78,8 +77,8 @@ module bsg_axil_fifo_client
 
   logic [axil_addr_width_p-1:0] awaddr_li;
   logic awaddr_v_li, awaddr_yumi_lo;
-  bsg_fifo_1r1w_small
-   #(.width_p(axil_addr_width_p), .els_p(fifo_els_p))
+  bsg_one_fifo
+   #(.width_p(axil_addr_width_p))
    awaddr_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -96,8 +95,8 @@ module bsg_axil_fifo_client
   logic [axil_data_width_p-1:0] wdata_li;
   logic [axil_mask_width_lp-1:0] wmask_li;
   logic wdata_v_li, wdata_yumi_lo;
-  bsg_fifo_1r1w_small
-   #(.width_p(axil_mask_width_lp+axil_data_width_p), .els_p(fifo_els_p))
+  bsg_one_fifo
+   #(.width_p(axil_mask_width_lp+axil_data_width_p))
    wdata_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -112,8 +111,8 @@ module bsg_axil_fifo_client
      );
 
   logic return_v_li, return_ready_lo, return_w_lo, return_v_lo, return_yumi_li;
-  bsg_fifo_1r1w_small
-   #(.width_p(1), .els_p(fifo_els_p), .ready_THEN_valid_p(1))
+  bsg_one_fifo
+   #(.width_p(1))
    return_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)

--- a/axi/v/bsg_axil_fifo_master.sv
+++ b/axi/v/bsg_axil_fifo_master.sv
@@ -5,7 +5,6 @@ module bsg_axil_fifo_master
  import bsg_axi_pkg::*;
  #(parameter `BSG_INV_PARAM(axil_data_width_p)
    , parameter `BSG_INV_PARAM(axil_addr_width_p)
-   , parameter `BSG_INV_PARAM(fifo_els_p)
 
    , localparam axi_mask_width_lp = axil_data_width_p >> 3
    )
@@ -57,8 +56,8 @@ module bsg_axil_fifo_master
   wire unused = &{m_axil_rresp_i, m_axil_bresp_i};
 
   logic wdata_ready_lo;
-  bsg_fifo_1r1w_small
-   #(.width_p(axil_data_width_p+axi_mask_width_lp), .els_p(fifo_els_p))
+  bsg_one_fifo
+   #(.width_p(axil_data_width_p+axi_mask_width_lp))
    wdata_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -75,8 +74,8 @@ module bsg_axil_fifo_master
   logic addr_ready_lo;
   logic w_lo, addr_v_lo, addr_yumi_li;
   logic [axil_addr_width_p-1:0] addr_lo;
-  bsg_fifo_1r1w_small
-   #(.width_p(1+axil_addr_width_p), .els_p(fifo_els_p))
+  bsg_one_fifo
+   #(.width_p(1+axil_addr_width_p))
    addr_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)
@@ -91,8 +90,8 @@ module bsg_axil_fifo_master
      );
 
   logic return_ready_lo, return_w_lo, return_v_lo, return_yumi_li;
-  bsg_fifo_1r1w_small
-   #(.width_p(1), .els_p(fifo_els_p))
+  bsg_one_fifo
+   #(.width_p(1))
    return_fifo
     (.clk_i(clk_i)
      ,.reset_i(reset_i)


### PR DESCRIPTION
There are a few axil ordering edge cases that we have not properly handled, so this patch removes the possibility by having only 1 transaction be outstanding at a time