### PR TITLE
handle data alignment in bp_me_axil converters

### DIFF
--- a/axi/v/bp_me_axil_client.sv
+++ b/axi/v/bp_me_axil_client.sv
@@ -111,13 +111,28 @@ module bp_me_axil_client
       mem_fwd_header_cast_o.payload.did    = did_i;
       mem_fwd_header_cast_o.addr           = addr_lo;
       mem_fwd_header_cast_o.msg_type       = w_lo ? e_bedrock_mem_uc_wr : e_bedrock_mem_uc_rd;
-      case (wmask_lo)
-        axil_mask_width_lp'('h1): mem_fwd_header_cast_o.size = e_bedrock_msg_size_1;
-        axil_mask_width_lp'('h3): mem_fwd_header_cast_o.size = e_bedrock_msg_size_2;
-        axil_mask_width_lp'('hF): mem_fwd_header_cast_o.size = e_bedrock_msg_size_4;
-        // axil_mask_width_lp'('hFF):
-        default: mem_fwd_header_cast_o.size = e_bedrock_msg_size_8;
-      endcase
+      if (~w_lo) begin
+        // reads are full width
+        mem_fwd_header_cast_o.size = bp_bedrock_msg_size_e'(lg_axil_mask_width_lp);
+      end else begin
+        case (wmask_lo)
+          axil_mask_width_lp'('h80)
+          ,axil_mask_width_lp'('h40)
+          ,axil_mask_width_lp'('h20)
+          ,axil_mask_width_lp'('h10)
+          ,axil_mask_width_lp'('h08)
+          ,axil_mask_width_lp'('h04)
+          ,axil_mask_width_lp'('h02): mem_fwd_header_cast_o.size = e_bedrock_msg_size_1;
+          axil_mask_width_lp'('hC0)
+          ,axil_mask_width_lp'('h30)
+          ,axil_mask_width_lp'('h0C)
+          ,axil_mask_width_lp'('h03): mem_fwd_header_cast_o.size = e_bedrock_msg_size_2;
+          axil_mask_width_lp'('hF0)
+          ,axil_mask_width_lp'('h0F): mem_fwd_header_cast_o.size = e_bedrock_msg_size_4;
+          // axil_mask_width_lp'('hFF):
+          default: mem_fwd_header_cast_o.size = e_bedrock_msg_size_8;
+        endcase
+      end
 
       mem_fwd_v_o = v_lo;
       ready_and_li = mem_fwd_ready_and_i;


### PR DESCRIPTION
This modifies bp_me_axil_client|master to add support for sub-data-width requests. This is more of a concern when used for outgoing requests from BP. AXIL expects the data to be placed in the correct byte location and the write strobe to match. BlackParrot top-levels already pack the data correctly, but currently the write strobe is always placed in the least significant bits. On the client side, all possible write masks need to be considered to generate the size of the outbound (to BP) bedrock message. This only really matters for sub-data-width modifications to DRAM or for 32-bit registers that are still located at 32b-aligned addresses.