### PR TITLE
handle data alignment in bp_me_axil converters

### DIFF
--- a/axi/v/bp_me_axil_client.sv
+++ b/axi/v/bp_me_axil_client.sv
@@ -98,6 +98,7 @@ module bp_me_axil_client
      ,.*
      );
 
+  localparam lg_axil_mask_width_lp = `BSG_SAFE_CLOG2(axil_mask_width_lp);
   always_comb
     begin
       mem_fwd_data_o = wdata_lo;

--- a/axi/v/bp_me_axil_client.sv
+++ b/axi/v/bp_me_axil_client.sv
@@ -106,13 +106,28 @@ module bp_me_axil_client
       mem_fwd_header_cast_o.payload.did    = did_i;
       mem_fwd_header_cast_o.addr           = addr_lo;
       mem_fwd_header_cast_o.msg_type       = w_lo ? e_bedrock_mem_uc_wr : e_bedrock_mem_uc_rd;
-      case (wmask_lo)
-        axil_mask_width_lp'('h1): mem_fwd_header_cast_o.size = e_bedrock_msg_size_1;
-        axil_mask_width_lp'('h3): mem_fwd_header_cast_o.size = e_bedrock_msg_size_2;
-        axil_mask_width_lp'('hF): mem_fwd_header_cast_o.size = e_bedrock_msg_size_4;
-        // axil_mask_width_lp'('hFF):
-        default: mem_fwd_header_cast_o.size = e_bedrock_msg_size_8;
-      endcase
+      if (~w_lo) begin
+        // reads are full width
+        mem_fwd_header_cast_o.size = bp_bedrock_msg_size_e'(lg_axil_mask_width_lp);
+      end else begin
+        case (wmask_lo)
+          axil_mask_width_lp'('h80)
+          ,axil_mask_width_lp'('h40)
+          ,axil_mask_width_lp'('h20)
+          ,axil_mask_width_lp'('h10)
+          ,axil_mask_width_lp'('h08)
+          ,axil_mask_width_lp'('h04)
+          ,axil_mask_width_lp'('h02): mem_fwd_header_cast_o.size = e_bedrock_msg_size_1;
+          axil_mask_width_lp'('hC0)
+          ,axil_mask_width_lp'('h30)
+          ,axil_mask_width_lp'('h0C)
+          ,axil_mask_width_lp'('h03): mem_fwd_header_cast_o.size = e_bedrock_msg_size_2;
+          axil_mask_width_lp'('hF0)
+          ,axil_mask_width_lp'('h0F): mem_fwd_header_cast_o.size = e_bedrock_msg_size_4;
+          // axil_mask_width_lp'('hFF):
+          default: mem_fwd_header_cast_o.size = e_bedrock_msg_size_8;
+        endcase
+      end
 
       mem_fwd_v_o = v_lo;
       ready_and_li = mem_fwd_ready_and_i;

--- a/axi/v/bp_me_axil_client.sv
+++ b/axi/v/bp_me_axil_client.sv
@@ -111,6 +111,8 @@ module bp_me_axil_client
         // reads are full width
         mem_fwd_header_cast_o.size = bp_bedrock_msg_size_e'(lg_axil_mask_width_lp);
       end else begin
+        // TODO: check address aligned with write strobes and for error cases (including mask 'h00),
+        // reply with AXIL error response, and do not send BedRock message.
         case (wmask_lo)
           axil_mask_width_lp'('h80)
           ,axil_mask_width_lp'('h40)
@@ -118,14 +120,15 @@ module bp_me_axil_client
           ,axil_mask_width_lp'('h10)
           ,axil_mask_width_lp'('h08)
           ,axil_mask_width_lp'('h04)
-          ,axil_mask_width_lp'('h02): mem_fwd_header_cast_o.size = e_bedrock_msg_size_1;
+          ,axil_mask_width_lp'('h02)
+          ,axil_mask_width_lp'('h01): mem_fwd_header_cast_o.size = e_bedrock_msg_size_1;
           axil_mask_width_lp'('hC0)
           ,axil_mask_width_lp'('h30)
           ,axil_mask_width_lp'('h0C)
           ,axil_mask_width_lp'('h03): mem_fwd_header_cast_o.size = e_bedrock_msg_size_2;
           axil_mask_width_lp'('hF0)
           ,axil_mask_width_lp'('h0F): mem_fwd_header_cast_o.size = e_bedrock_msg_size_4;
-          // axil_mask_width_lp'('hFF):
+          axil_mask_width_lp'('hFF): mem_fwd_header_cast_o.size = e_bedrock_msg_size_8;
           default: mem_fwd_header_cast_o.size = e_bedrock_msg_size_8;
         endcase
       end

--- a/axi/v/bp_me_axil_master.sv
+++ b/axi/v/bp_me_axil_master.sv
@@ -165,19 +165,10 @@ module bp_me_axil_master
       w_li = fsm_fwd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr};
       fsm_fwd_yumi_lo = fsm_fwd_v_li & ready_and_lo & stream_fifo_ready_and_lo;
 
-<<<<<<< HEAD
       case (fsm_fwd_header_li.size)
-        e_bedrock_msg_size_1: wmask_li = (axil_mask_width_p)'('h1) << mask_shift;
-        e_bedrock_msg_size_2: wmask_li = (axil_mask_width_p)'('h3) << mask_shift;
-        e_bedrock_msg_size_4: wmask_li = (axil_mask_width_p)'('hF) << mask_shift;
-=======
-      header_v_li = mem_fwd_ready_and_o & mem_fwd_v_i;
-
-      case (mem_fwd_header_cast_i.size)
         e_bedrock_msg_size_1: wmask_li = (axil_mask_width_lp)'('h1) << mask_shift;
         e_bedrock_msg_size_2: wmask_li = (axil_mask_width_lp)'('h3) << mask_shift;
         e_bedrock_msg_size_4: wmask_li = (axil_mask_width_lp)'('hF) << mask_shift;
->>>>>>> fix typos
         // e_bedrock_msg_size_8:
         default : wmask_li = (axil_mask_width_lp)'('hFF);
       endcase

--- a/axi/v/bp_me_axil_master.sv
+++ b/axi/v/bp_me_axil_master.sv
@@ -42,7 +42,7 @@ module bp_me_axil_master
 
   // WRITE DATA CHANNEL SIGNALS
   , output logic [axil_data_width_p-1:0]       m_axil_wdata_o
-  , output logic [axil_mask_width_p-1:0]       m_axil_wstrb_o
+  , output logic [axil_mask_width_lp-1:0]      m_axil_wstrb_o
   , output logic                               m_axil_wvalid_o
   , input                                      m_axil_wready_i
 
@@ -154,7 +154,7 @@ module bp_me_axil_master
   logic v_li, w_li, ready_and_lo;
   logic [axil_mask_width_lp-1:0] wmask_li;
 
-  localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(axil_mask_width_p);
+  localparam byte_offset_width_lp = `BSG_SAFE_CLOG2(axil_mask_width_lp);
   wire [byte_offset_width_lp-1:0] mask_shift = addr_li[0+:byte_offset_width_lp];
 
   always_comb
@@ -165,12 +165,21 @@ module bp_me_axil_master
       w_li = fsm_fwd_header_li.msg_type inside {e_bedrock_mem_wr, e_bedrock_mem_uc_wr};
       fsm_fwd_yumi_lo = fsm_fwd_v_li & ready_and_lo & stream_fifo_ready_and_lo;
 
+<<<<<<< HEAD
       case (fsm_fwd_header_li.size)
         e_bedrock_msg_size_1: wmask_li = (axil_mask_width_p)'('h1) << mask_shift;
         e_bedrock_msg_size_2: wmask_li = (axil_mask_width_p)'('h3) << mask_shift;
         e_bedrock_msg_size_4: wmask_li = (axil_mask_width_p)'('hF) << mask_shift;
+=======
+      header_v_li = mem_fwd_ready_and_o & mem_fwd_v_i;
+
+      case (mem_fwd_header_cast_i.size)
+        e_bedrock_msg_size_1: wmask_li = (axil_mask_width_lp)'('h1) << mask_shift;
+        e_bedrock_msg_size_2: wmask_li = (axil_mask_width_lp)'('h3) << mask_shift;
+        e_bedrock_msg_size_4: wmask_li = (axil_mask_width_lp)'('hF) << mask_shift;
+>>>>>>> fix typos
         // e_bedrock_msg_size_8:
-        default : wmask_li = (axil_mask_width_p)'('hFF);
+        default : wmask_li = (axil_mask_width_lp)'('hFF);
       endcase
     end
 

--- a/axi/v/bp_me_axil_master.sv
+++ b/axi/v/bp_me_axil_master.sv
@@ -70,7 +70,7 @@ module bp_me_axil_master
   `bp_cast_o(bp_bedrock_mem_rev_header_s, mem_rev_header);
 
   bp_bedrock_mem_fwd_header_s fsm_fwd_header_li;
-  logic [axil_data_width_p-1:0] fsm_fwd_data_li;
+  logic [bedrock_fill_width_p-1:0] fsm_fwd_data_li;
   logic fsm_fwd_v_li, fsm_fwd_yumi_lo;
   logic [paddr_width_p-1:0] fsm_fwd_stream_addr_li;
   bp_me_stream_pump_in
@@ -103,7 +103,7 @@ module bp_me_axil_master
 
   bp_bedrock_mem_rev_header_s fsm_rev_header_li;
   logic [paddr_width_p-1:0] fsm_rev_addr_lo;
-  logic [l2_data_width_p-1:0] fsm_rev_data_li;
+  logic [bedrock_fill_width_p-1:0] fsm_rev_data_li;
   logic fsm_rev_v_li, fsm_rev_yumi_lo;
   logic fsm_rev_new_lo, fsm_rev_last_lo;
   logic stream_fifo_ready_and_lo;
@@ -124,7 +124,7 @@ module bp_me_axil_master
 
   bp_me_stream_pump_out
    #(.bp_params_p(bp_params_p)
-     ,.stream_data_width_p(axil_data_width_p)
+     ,.stream_data_width_p(bedrock_fill_width_p)
      ,.block_width_p(bedrock_block_width_p)
      ,.payload_width_p(mem_rev_payload_width_lp)
      ,.msg_stream_mask_p(mem_rev_payload_mask_gp)


### PR DESCRIPTION
This modifies bp_me_axil_client|master to add support for sub-data-width requests. This is more of a concern when used for outgoing requests from BP. AXIL expects the data to be placed in the correct byte location and the write strobe to match. BlackParrot top-levels already pack the data correctly, but currently the write strobe is always placed in the least significant bits. On the client side, all possible write masks need to be considered to generate the size of the outbound (to BP) bedrock message. This only really matters for sub-data-width modifications to DRAM or for 32-bit registers that are still located at 32b-aligned addresses.